### PR TITLE
Remove .git folder to make seeds work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN yarn install
 # Copy the rest of the application into the container.
 COPY . /app
 
+# Remove the .git folder, without doing this the public repositories cannot be
+# cloned in the seeds.
+RUN rm -r /app/.git
+
 # Patch the database host. This is needed because the localhost socket does not
 # exist on this container.
 RUN sed -i 's+localhost+database+g' /app/config/database.yml


### PR DESCRIPTION
When running the seeds, the public repositories are cloned. Prior to doing so, `git ls-remote` is executed to make sure the code has access to that repository.

However, if this `git ls-remote` command is executed from within an existing git repository ( -> the dodona application), access to that remote is required for the command to work. This PR removes the `.git` folder from the dodona application folder so that it is no longer considered a repository and the `git ls-remote` command works correctly.

## Example

```
root@dodona:/app# git ls-remote https://github.com/dodona-edu/judge-java12
Username for 'https://github.com': (login required)
Password for 'https://(login required)@github.com':
 
root@dodona:/app# cd ..

root@dodona:/# git ls-remote https://github.com/dodona-edu/judge-java12
471c2795cf33d2fe9c877708735b0ed2fa518dba	HEAD
5e22859049212e7c2208e09626857466a40d72e0	refs/heads/feature/security
26bd1aa2383477c95720d689dfde7155fac32cbb	refs/heads/fix/access-error
471c2795cf33d2fe9c877708735b0ed2fa518dba	refs/heads/master
529619954474ddb676de8c30e76acf46be74ef62	refs/heads/openjdk-12-alpine
9754d32b0b6bf0f8d4667d93a993f779ae534317	refs/pull/1/head
18d6a4915a6573d6108fa26109934169d6e3ada7	refs/pull/10/head
777ea8ec981299ba5d81601bc9fcbed0482ff097	refs/pull/11/head
8a113af511d43cd200ef970841ffe602aa63db03	refs/pull/12/head
..... more stuff goes here .............        .................
```